### PR TITLE
🐛 #5 backdropの背景を黒ベースにして透明度を下げた＆ポップアップ表示中はスクロールできないようにした

### DIFF
--- a/components/popup-wrapper.js
+++ b/components/popup-wrapper.js
@@ -15,7 +15,7 @@ class PopupWrapper extends HTMLElement {
           display: none;
           align-items: center;
           justify-content: center;
-          background: rgba(255,255,255,0.25);
+          background: rgba(0,0,0,0.7);
         }
         .popup-backdrop[open] { display: flex; }
         .popup-content {
@@ -51,6 +51,7 @@ class PopupWrapper extends HTMLElement {
     `;
 	}
 	connectedCallback() {
+		this._body = document.body;
 		this._backdrop = this.shadowRoot.querySelector(".popup-backdrop");
 		this.shadowRoot
 			.querySelector(".close-btn")
@@ -61,9 +62,11 @@ class PopupWrapper extends HTMLElement {
 	}
 	open() {
 		this._backdrop.setAttribute("open", "");
+		this._body.style.overflow = "hidden";
 	}
 	close() {
 		this._backdrop.removeAttribute("open");
+		this._body.style.overflow = "";
 	}
 }
 customElements.define("popup-wrapper", PopupWrapper);


### PR DESCRIPTION
This pull request updates the `PopupWrapper` web component to improve the user experience when displaying popups. The main changes focus on enhancing the popup's visual appearance and preventing background scrolling while the popup is open.

**Visual and UX improvements:**

* Changed the popup backdrop color to a darker, more opaque shade for better contrast and focus on the popup (`components/popup-wrapper.js`).
* Disabled background scrolling by setting `document.body.style.overflow = "hidden"` when the popup opens, and restored scrolling when the popup closes (`components/popup-wrapper.js`). [[1]](diffhunk://#diff-b18c0945391cf539a0afa56bea23184a7c4efc942c1fd5db63ce5ea580ff8330R54) [[2]](diffhunk://#diff-b18c0945391cf539a0afa56bea23184a7c4efc942c1fd5db63ce5ea580ff8330R65-R69)